### PR TITLE
Add tweakcn theme toggle with persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "lodash": "^4.17.21",
         "lucide-react": "^0.544.0",
         "next": "15.5.3",
+        "next-themes": "^0.4.6",
         "openai": "^6.0.0",
         "react": "19.1.0",
         "react-colorful": "^5.6.1",
@@ -5410,6 +5411,15 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lodash": "^4.17.21",
     "lucide-react": "^0.544.0",
     "next": "15.5.3",
+    "next-themes": "^0.4.6",
     "openai": "^6.0.0",
     "react": "19.1.0",
     "react-colorful": "^5.6.1",


### PR DESCRIPTION
## Summary
- add `next-themes` provider and tweakcn-style toggle with shared AppHeader
- ensure home and notes respect the toggle while relying on existing Notebook CSS variables
- convert legacy Playwright helpers to TypeScript and add a regression spec for theme persistence

## Testing
- `npm run lint`
- `PLAYWRIGHT_BASE_URL=http://localhost:3002 npx playwright test theme-toggle.spec.ts --project=chromium` *(fails in sandbox: Chromium headless shell forbidden to register Mach port / bootstrap_check_in permission denied)*
