### PR TITLE
Auto-delete empty journal entries after 24 hours

### DIFF
--- a/src/components/journal/JournalStream.tsx
+++ b/src/components/journal/JournalStream.tsx
@@ -12,7 +12,7 @@ import { NoteViewer } from '@/components/notes/NoteViewer'
 import { Note } from '@/types/note'
 import { createLink, getOutgoingLinks } from '@/lib/supabase/notes'
 import { convertTextToLink, captureSelectionMetadata, rehydrateLinksFromMetadata } from '@/utils/textToLink'
-import { getNotes, createNote, updateNote as updateNoteInDb } from '@/lib/notes'
+import { getNotes, createNote, updateNote as updateNoteInDb, deleteNote } from '@/lib/notes'
 import { useAuth } from '@/contexts/AuthContext'
 import { toast } from 'sonner'
 
@@ -75,8 +75,28 @@ export function JournalStream() {
         const allNotes = await getNotes(user.id)
         console.log('[JournalStream] Fetched notes:', allNotes.length)
 
-        // Filter to journal entries only
-        const journalNotes = allNotes.filter(note => note.noteType === 'journal-entry')
+        // Clean up empty journal entries older than 24 hours (Issue #10)
+        const now = new Date()
+        const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000)
+
+        const emptyJournalEntries = allNotes.filter(note =>
+          note.noteType === 'journal-entry' &&
+          note.content.trim() === '' &&
+          new Date(note.createdAt) < oneDayAgo
+        )
+
+        if (emptyJournalEntries.length > 0) {
+          console.log(`[JournalStream] Cleaning up ${emptyJournalEntries.length} empty journal entries older than 24 hours`)
+          await Promise.all(
+            emptyJournalEntries.map(note => deleteNote(note.id, user.id))
+          )
+        }
+
+        // Filter to journal entries only (excluding the ones we just deleted)
+        const journalNotes = allNotes.filter(note =>
+          note.noteType === 'journal-entry' &&
+          !emptyJournalEntries.some(empty => empty.id === note.id)
+        )
 
         // Convert Note format to JournalEntry format
         const journalEntries: JournalEntry[] = journalNotes.map(note => {


### PR DESCRIPTION
## Summary

Implements automatic cleanup of empty journal entries older than 24 hours to resolve visual clutter in the journal UI (fixes #10).

**Problem:** The app creates a "Today" journal entry on every page load, even if users don't write anything. These empty entries accumulate and create repetitive cards showing only placeholder text.

**Solution:** Client-side cleanup on app load that:
- Detects journal entries with empty/whitespace-only content
- Deletes entries created more than 24 hours ago
- Preserves today's empty entry and any entries with actual content
- Filters deleted entries from UI to prevent flicker

## Changes

- **src/components/journal/JournalStream.tsx**:
  - Import `deleteNote` function from `/src/lib/notes`
  - Add cleanup logic in `loadEntries()` effect (lines 78-93)
  - Filter deleted entries from display (line 98)
  - Add console logging for cleanup operations

## Technical Details

**Cleanup Logic:**
```typescript
const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000)
const emptyJournalEntries = allNotes.filter(note =>
  note.noteType === 'journal-entry' &&
  note.content.trim() === '' &&
  new Date(note.createdAt) < oneDayAgo
)
```

**Edge Cases Handled:**
- ✅ Timezone-aware (uses local time)
- ✅ Preserves intentional empty entries < 24 hours old
- ✅ Only deletes truly empty content (`content.trim() === ''`)
- ✅ Idempotent (safe if multiple tabs open)
- ✅ Runs on each page load (no server infrastructure needed)

## Test Plan

### Manual Testing
- [ ] Create empty journal entry, wait >24 hours → deleted on next load
- [ ] Create empty journal entry today → NOT deleted (< 24 hours)
- [ ] Create journal entry with content, wait >24 hours → NOT deleted
- [ ] Multiple empty entries from different days → only stale ones deleted
- [ ] Browser console shows cleanup logs when entries are deleted
- [ ] No UI flicker or "flash of empty content"

### Vercel Preview Testing
1. Deploy to preview environment
2. Create test entries with different timestamps via Supabase
3. Verify cleanup behavior with production database
4. Check console logs for cleanup operations
5. Confirm no performance degradation on load

## Screenshots

_To be added after Vercel preview deployment_

**Before:** Multiple empty "Today" entries with placeholder text
**After:** Clean journal view showing only entries with content

## Related Issues

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)