### PR TITLE
Fix: Cognitive distortions helper not showing on today's entry

### DIFF
--- a/src/components/journal/JournalStream.tsx
+++ b/src/components/journal/JournalStream.tsx
@@ -475,7 +475,7 @@ export function JournalStream() {
   }
 
   const isToday = (dateStr: string) => {
-    const today = new Date().toISOString().split('T')[0]
+    const today = getLocalDateString()
     return dateStr === today
   }
 


### PR DESCRIPTION
## Summary

Fixed a timezone bug that prevented the cognitive distortions helper from appearing on today's journal entry.

## Root Cause

The `isToday()` function was using UTC date (`new Date().toISOString().split('T')[0]`) while `getLocalDateString()` uses local timezone. When the user's local date differs from UTC date (e.g., in timezones ahead or behind UTC at day boundaries), the helper wouldn't show because the date comparison failed.

## Changes

- Updated `isToday()` in `src/components/journal/JournalStream.tsx:478` to use `getLocalDateString()` for consistent date comparison in local timezone
- This ensures both functions use the same date calculation method

## Test Plan

- [x] Build passes locally  
- [x] Dev server starts without errors
- [ ] Test on Vercel preview: Verify helper appears on today's entry
- [ ] Test in different timezones if possible
- [ ] Check that helper still doesn't appear on previous days' entries

## Screenshots

**Before:** Helper missing despite being today's entry (see attached image in issue)

**After:** Helper should now appear on today's entry

## Related

Fixes the issue where cognitive distortions helper was not appearing in today's journal entry despite the entry being correctly identified as "Today" in the UI.