### PR TITLE
Fix: Remove internal scrolling from CBT helper

### DIFF
--- a/src/components/journal/helpers/CbtDistortions.tsx
+++ b/src/components/journal/helpers/CbtDistortions.tsx
@@ -184,7 +184,7 @@ export function CbtDistortions({ entryId, userId, onInsert }: CbtDistortionsProp
         testId="cbt"
       >
         {/* Distortion checkboxes */}
-        <div className="space-y-3 max-h-[400px] overflow-y-auto pr-2">
+        <div className="space-y-3 pr-2">
           {CBT_DISTORTIONS.map((distortion) => (
             <div
               key={distortion.id}


### PR DESCRIPTION
## Summary
- Removed `max-h-[400px] overflow-y-auto` from CBT distortions container
- All 10 cognitive distortions now display without internal scrolling
- Users scroll the page normally instead of within the helper element

## Changes
**File:** `src/components/journal/helpers/CbtDistortions.tsx:187`
- **Before:** `<div className="space-y-3 max-h-[400px] overflow-y-auto pr-2">`
- **After:** `<div className="space-y-3 pr-2">`

## Test Plan
- [ ] Open journal entry with CBT helper
- [ ] Click "Explore" to expand the helper
- [ ] Verify all 10 distortions are visible without scrolling within the element
- [ ] Verify page scrolls normally to view all content
- [ ] Test on both desktop and mobile viewports
- [ ] Verify dark mode styling still works correctly

## Screenshots
*(Will be added after testing on Vercel preview)*

Fixes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed height constraints and automatic scrolling from the distortion checkboxes list, allowing all items to display without truncation on the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->