### PR TITLE
Fix: Empty journal entries not being deleted due to HTML content (#67)

### DIFF
--- a/src/components/journal/JournalStream.tsx
+++ b/src/components/journal/JournalStream.tsx
@@ -73,13 +73,23 @@ export function JournalStream() {
         const allNotes = await getNotes(user.id)
         console.log('[JournalStream] Fetched notes:', allNotes.length)
 
-        // Clean up empty journal entries older than 24 hours (Issue #10)
+        // Clean up empty journal entries older than 24 hours (Issue #10, #67)
         const now = new Date()
         const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000)
 
+        // Helper function to check if content is truly empty (handles HTML markup)
+        const isContentEmpty = (html: string): boolean => {
+          if (!html || html.trim() === '') return true
+          // Create a temporary element to parse HTML and extract text
+          const tempDiv = document.createElement('div')
+          tempDiv.innerHTML = html
+          const text = tempDiv.textContent || tempDiv.innerText || ''
+          return text.trim() === ''
+        }
+
         const emptyJournalEntries = allNotes.filter(note =>
           note.noteType === 'journal-entry' &&
-          note.content.trim() === '' &&
+          isContentEmpty(note.content) &&
           new Date(note.createdAt) < oneDayAgo
         )
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "vitest.config.ts"]
 }


### PR DESCRIPTION
## Summary

Fixes the empty journal entry auto-deletion feature (from PR #35) which wasn't working because it didn't account for HTML markup in "empty" entries.

Fixes #67

## Problem

The auto-deletion feature from PR #35 checked for `content.trim() === ''`, but the `SimpleRichEditor` component saves content as `innerHTML`, which means "empty" entries actually contain HTML markup like:
- `<br>`
- `<p><br></p>`
- `<div><br></div>`

These HTML strings don't match the empty string check, so entries were never deleted.

## Evidence

From console logs, no cleanup was happening:
```
[JournalStream] Fetched notes: 26
[JournalStream] Setting entries: 10
```

**Expected:** Should see `[JournalStream] Cleaning up X empty journal entries older than 24 hours`
**Actual:** No cleanup log appeared

## Solution

### 1. Added `isContentEmpty()` Helper Function

```typescript
const isContentEmpty = (html: string): boolean => {
  if (!html || html.trim() === '') return true
  // Create a temporary element to parse HTML and extract text
  const tempDiv = document.createElement('div')
  tempDiv.innerHTML = html
  const text = tempDiv.textContent || tempDiv.innerText || ''
  return text.trim() === ''
}
```

This function:
- Parses the HTML string into a DOM element
- Extracts the actual text content (ignoring markup)
- Returns true only if there's no meaningful text

### 2. Updated Entry Filter

Changed from:
```typescript
const emptyJournalEntries = allNotes.filter(note =>
  note.noteType === 'journal-entry' &&
  note.content.trim() === '' &&
  new Date(note.createdAt) < oneDayAgo
)
```

To:
```typescript
const emptyJournalEntries = allNotes.filter(note =>
  note.noteType === 'journal-entry' &&
  isContentEmpty(note.content) &&
  new Date(note.createdAt) < oneDayAgo
)
```

### 3. TypeScript Build Fix

Excluded `vitest.config.ts` from TypeScript compilation (vitest is not installed as a dependency).

## Changes

- **src/components/journal/JournalStream.tsx**: 
  - Added `isContentEmpty()` helper function (lines 81-88)
  - Updated empty entry filter to use new helper (line 92)
  - Updated issue reference comment (line 76)
  
- **tsconfig.json**:
  - Added `vitest.config.ts` to exclude list to fix build errors

## Test Plan

### Vercel Preview Testing

1. **Test empty HTML entries:**
   - Create a journal entry with just `<br>` or `<p><br></p>` in database
   - Set `created_at` to >24 hours ago
   - Load journal page
   - ✅ Verify console shows cleanup log
   - ✅ Verify entry is deleted from UI

2. **Test today's empty entry:**
   - Load journal page (creates empty today entry)
   - ✅ Verify today's entry is NOT deleted
   - ✅ Verify no cleanup log for today

3. **Test entries with content:**
   - Create entry with actual text >24 hours old
   - ✅ Verify it's NOT deleted
   - ✅ Verify it remains in UI

4. **Test edge cases:**
   - Entry with whitespace only: `<p>   </p>` → should be deleted
   - Entry with nbsp: `<p>&nbsp;</p>` → should be deleted
   - Entry with actual text: `<p>Hello</p>` → should NOT be deleted

### Console Log Verification

After fix, should see logs like:
```
[JournalStream] Fetched notes: 26
[JournalStream] Cleaning up 3 empty journal entries older than 24 hours
[JournalStream] Setting entries: 7
```

## Related

- Original PR: #35
- Original issue: #10
- Bug report: #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)