### PR TITLE
Move WYSIWYG toolbar to bottom for smoother edit transition

### DIFF
--- a/src/components/editor/SimpleRichEditor.tsx
+++ b/src/components/editor/SimpleRichEditor.tsx
@@ -234,8 +234,29 @@ export function SimpleRichEditor({
 
   return (
     <div className="relative min-h-[120px] w-full border rounded-md overflow-hidden">
+      {/* Editor */}
+      <div className="relative">
+        <div
+          ref={editorRef}
+          contentEditable
+          suppressContentEditableWarning={true}
+          onInput={handleInput}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          onPaste={handlePaste}
+          className="min-h-[120px] w-full resize-none border-0 bg-transparent p-4 text-foreground focus:outline-none focus:ring-0 text-base leading-relaxed"
+          style={{ whiteSpace: 'pre-wrap' }}
+        />
+        {/* Placeholder */}
+        {(!value && !initialValue) && (
+          <div className="absolute left-4 top-4 text-muted-foreground pointer-events-none select-none text-base">
+            {placeholder}
+          </div>
+        )}
+      </div>
+
       {/* Formatting Toolbar */}
-      <div className="flex items-center gap-1 p-2 border-b bg-muted/50 flex-wrap">
+      <div className="flex items-center gap-1 p-2 border-t bg-muted/50 flex-wrap">
         {/* Text Formatting */}
         <div className="flex items-center gap-1 border-r pr-2 mr-2">
           <Button
@@ -390,27 +411,6 @@ export function SimpleRichEditor({
         <div className="flex items-center border-l pl-2 ml-2" data-voice-button>
           <VoiceRecordButton onTranscriptionComplete={handleTranscription} />
         </div>
-      </div>
-
-      {/* Editor */}
-      <div className="relative">
-        <div
-          ref={editorRef}
-          contentEditable
-          suppressContentEditableWarning={true}
-          onInput={handleInput}
-          onFocus={onFocus}
-          onBlur={onBlur}
-          onPaste={handlePaste}
-          className="min-h-[120px] w-full resize-none border-0 bg-transparent p-4 text-foreground focus:outline-none focus:ring-0 text-base leading-relaxed"
-          style={{ whiteSpace: 'pre-wrap' }}
-        />
-        {/* Placeholder */}
-        {(!value && !initialValue) && (
-          <div className="absolute left-4 top-4 text-muted-foreground pointer-events-none select-none text-base">
-            {placeholder}
-          </div>
-        )}
       </div>
 
     </div>


### PR DESCRIPTION
## Summary
Fixes #80 

Moves the WYSIWYG toolbar from the top to the bottom of the input field to reduce visual jarring when transitioning from read mode to edit mode in journal entries.

## Changes
- Reordered DOM structure: editor contentEditable area now renders before the toolbar
- Changed toolbar border from `border-b` to `border-t` to reflect new position
- All functionality preserved:
  - Text formatting buttons (Bold, Italic, Underline)
  - Heading buttons (H1, H2)
  - List buttons (Bullet, Numbered)
  - Alignment buttons (Left, Center, Right)
  - Quote/Indent button
  - **Make Note button** (conditional rendering based on text selection)
  - **Voice transcription button**

## Test Plan
- [ ] Click into a journal entry in read mode and verify the cursor position doesn't jump dramatically
- [ ] Test all formatting buttons work correctly
- [ ] Select text and verify the "Make Note" button appears and functions
- [ ] Test voice transcription button works
- [ ] Verify visual appearance is consistent with existing design
- [ ] Test on Vercel preview deployment

## Screenshots
Before: Toolbar at top (causes jarring transition)
After: Toolbar at bottom (smooth transition)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized the rich editor layout for improved visual hierarchy.
  * Updated the toolbar separator styling for better visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->