### PR TITLE
Fix microphone button tooltip text

### DIFF
--- a/src/components/editor/VoiceRecordButton.tsx
+++ b/src/components/editor/VoiceRecordButton.tsx
@@ -104,7 +104,7 @@ export function VoiceRecordButton({
       return status.errorMessage || 'Recording error'
     }
     if (status.state === 'idle') {
-      return `Transcribe${codecInfo ? ` (${codecInfo})` : ''}`
+      return 'Transcribe'
     }
     if (status.state === 'recording') {
       return 'Stop recording'


### PR DESCRIPTION
## Summary
- Changed microphone button tooltip from "Transcribe (using WEBM-OPUS codec)" to simply "Transcribe"
- Improves UX with cleaner, more concise tooltip text

## Changes
- Modified `VoiceRecordButton.tsx` line 107 to remove codec information from tooltip

## Test Plan
- [ ] Hover over microphone button in rich text editor
- [ ] Verify tooltip displays "Transcribe" instead of "Transcribe (using WEBM-OPUS codec)"
- [ ] Verify button functionality remains unchanged

## Screenshots
Before: Tooltip showed "Transcribe (using WEBM-OPUS codec)"
After: Tooltip shows "Transcribe"