### PR TITLE
Fix helper tiles layout and update titles for better UX

### DIFF
--- a/docs/stories/story-2.8-helpers-tile-ui.md
+++ b/docs/stories/story-2.8-helpers-tile-ui.md
@@ -60,13 +60,14 @@ so that I can see all available helpers at once without excessive scrolling.
    - Touch-friendly (>=44x44px targets)
 
 3. **Title & Description Pairs**
-   - "Thinking Traps" + "Identify unhelpful thought patterns" (icon: 🧠)
-   - "3 Good Things" + "Reflect on what went well today" (icon: ✨)
-   - "Values" + "Clarify what matters most to you" (icon: 🎯)
-   - "Self-Compassion" + "Give yourself kindness when struggling" (icon: 💚)
-   - "WOOP Goals" + "Plan goals with evidence-based strategy" (icon: 🎯)
-   - "Best Possible Self" + "Envision your ideal future" (icon: 🌟)
+   - "Bad Thinking" + "Identify unhelpful thought patterns" (icon: 🧠)
+   - "Gratitude" + "Reflect on what went well today" (icon: ✨)
+   - "Values Affirmation" + "Clarify what matters most to you" (icon: 🎯)
+   - "Self Compassion" + "Give yourself kindness when struggling" (icon: 💚)
+   - "Goal Planning" + "Plan goals with evidence-based strategy" (icon: 🚀)
+   - "Best Self" + "Envision your ideal future" (icon: 🌟)
    - "Savoring" + "Amplify positive experiences" (icon: 🌸)
+   - "Loving Kindness" + "Cultivate compassion for yourself and others" (icon: 💝)
 
 4. **Sheet/Dialog Implementation**
    - **Desktop (>=lg)**: Sheet component (right-side panel) keeps journal context visible
@@ -228,37 +229,37 @@ export interface HelperTileData {
 
 export const HELPER_TILES: Record<HelperType, HelperTileData> = {
   'cbt-distortions': {
-    shortTitle: 'Thinking Traps',
+    shortTitle: 'Bad Thinking',
     description: 'Identify unhelpful thought patterns',
     fullTitle: 'Cognitive Distortions',
     icon: '🧠',
   },
   'gratitude': {
-    shortTitle: '3 Good Things',
+    shortTitle: 'Gratitude',
     description: 'Reflect on what went well today',
     fullTitle: 'Gratitude Practice',
     icon: '✨',
   },
   'values-affirmation': {
-    shortTitle: 'Values',
+    shortTitle: 'Values Affirmation',
     description: 'Clarify what matters most to you',
     fullTitle: 'Values Affirmation',
     icon: '🎯',
   },
   'self-compassion': {
-    shortTitle: 'Self-Compassion',
+    shortTitle: 'Self Compassion',
     description: 'Give yourself kindness when struggling',
     fullTitle: 'Self-Compassion Break',
     icon: '💚',
   },
   'woop': {
-    shortTitle: 'WOOP Goals',
+    shortTitle: 'Goal Planning',
     description: 'Plan goals with evidence-based strategy',
     fullTitle: 'WOOP Goal Planning',
-    icon: '🎯',
+    icon: '🚀',
   },
   'best-possible-self': {
-    shortTitle: 'Best Possible Self',
+    shortTitle: 'Best Self',
     description: 'Envision your ideal future',
     fullTitle: 'Best Possible Self Exercise',
     icon: '🌟',
@@ -268,6 +269,12 @@ export const HELPER_TILES: Record<HelperType, HelperTileData> = {
     description: 'Amplify positive experiences',
     fullTitle: 'Savoring Practice',
     icon: '🌸',
+  },
+  'loving-kindness': {
+    shortTitle: 'Loving Kindness',
+    description: 'Cultivate compassion for yourself and others',
+    fullTitle: 'Loving-Kindness Meditation',
+    icon: '💝',
   },
 }
 ```

--- a/src/components/journal/helpers/HelperTileGrid.tsx
+++ b/src/components/journal/helpers/HelperTileGrid.tsx
@@ -49,8 +49,8 @@ export function HelperTileGrid({
         Need help journaling? Check out our helpers.
       </h2>
 
-      {/* Grid: 4 cols (xl), 3 cols (lg), 2 cols (md), 1 col (sm) */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+      {/* Grid: 3 cols (lg+), 2 cols (sm), 1 col (mobile) */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {helperTypes.map((helperType) => {
           const tileData = HELPER_TILES[helperType]
           if (!tileData) return null

--- a/src/constants/helperTitles.ts
+++ b/src/constants/helperTitles.ts
@@ -20,19 +20,19 @@ export interface HelperTileData {
 
 export const HELPER_TILES: Record<HelperType, HelperTileData> = {
   'cbt-distortions': {
-    shortTitle: 'Thinking Traps',
+    shortTitle: 'Bad Thinking',
     description: 'Identify unhelpful thought patterns',
     fullTitle: 'Cognitive Distortions',
     icon: '🧠',
   },
   gratitude: {
-    shortTitle: '3 Good Things',
+    shortTitle: 'Gratitude',
     description: 'Reflect on what went well today',
     fullTitle: 'Gratitude Practice',
     icon: '✨',
   },
   'values-affirmation': {
-    shortTitle: 'Values',
+    shortTitle: 'Values Affirmation',
     description: 'Clarify what matters most to you',
     fullTitle: 'Values Affirmation',
     icon: '🎯',
@@ -44,13 +44,13 @@ export const HELPER_TILES: Record<HelperType, HelperTileData> = {
     icon: '💚',
   },
   woop: {
-    shortTitle: 'WOOP Goals',
+    shortTitle: 'Goal Planning',
     description: 'Plan goals with evidence-based strategy',
     fullTitle: 'WOOP Goal Planning',
     icon: '🚀',
   },
   'best-possible-self': {
-    shortTitle: 'Best Possible Self',
+    shortTitle: 'Best Self',
     description: 'Envision your ideal future',
     fullTitle: 'Best Possible Self Exercise',
     icon: '🌟',
@@ -62,7 +62,7 @@ export const HELPER_TILES: Record<HelperType, HelperTileData> = {
     icon: '🌸',
   },
   'loving-kindness': {
-    shortTitle: 'Loving-Kindness',
+    shortTitle: 'Loving Kindness',
     description: 'Cultivate compassion for yourself and others',
     fullTitle: 'Loving-Kindness Meditation',
     icon: '💝',


### PR DESCRIPTION
## Summary
Improves helper tiles UX by fixing layout issues and clarifying tile titles.

### Changes
- **Layout**: Changed grid from 4 columns to 3 columns in desktop mode (removes `xl:grid-cols-4` breakpoint)
- **Tile Titles**: Renamed all tiles for clarity and consistency:
  - "Thinking Traps" → "Bad Thinking"
  - "3 Good Things" → "Gratitude"
  - "Values" → "Values Affirmation"
  - "WOOP Goals" → "Goal Planning"
  - "Best Possible Self" → "Best Self"
  - "Loving-Kindness" → "Loving Kindness"
  - "Self-Compassion" → "Self Compassion"
- **Documentation**: Updated story documentation to reflect new titles

## Screenshots
### Before (4 columns with truncated titles)
![Before](https://github.com/user-attachments/assets/f092c768-b864-4222-a926-424cc74f9241)

### After (3 columns with full titles)
Will be visible on Vercel preview deployment

## Test Plan
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] No old title references in source code
- [ ] Test on Vercel preview:
  - [ ] Desktop view shows 3 columns of tiles
  - [ ] All tile titles are fully visible (no ellipses)
  - [ ] Tiles are equal size
  - [ ] Click each tile to verify helper dialogs still work
  - [ ] Verify responsive behavior (mobile: 1 col, tablet: 2 cols, desktop: 3 cols)

## Related
Closes #99

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Loving-Kindness Meditation" helper tile to the collection.
  * Info icon interaction added to helper tiles for additional details.

* **Improvements**
  * Updated helper tile labels for improved clarity (e.g., "Bad Thinking," "Goal Planning," "Best Self").
  * Refined grid layout for better responsiveness across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->