### PR TITLE
Fix: Line break consistency between edit and read-only modes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -212,6 +212,22 @@
     border-width: 0;
   }
 
+  /* Rich text editor paragraph styling */
+  /* Match prose paragraph spacing for consistency between edit and read-only modes */
+  .rich-editor-body p {
+    margin-top: 0.75rem;
+    margin-bottom: 0.75rem;
+    line-height: 1.75;
+  }
+
+  .rich-editor-body p:first-child {
+    margin-top: 0;
+  }
+
+  .rich-editor-body p:last-child {
+    margin-bottom: 0;
+  }
+
   /* Rich text editor list styling */
   /* Override Tailwind's preflight reset to show bullets/numbers in contentEditable */
   .rich-editor-body ul {


### PR DESCRIPTION
## Summary

Fixes #131 - Line breaks now display identically in edit mode and read-only mode.

## Root Cause

The `.prose` class (read-only mode) had explicit paragraph spacing (`margin-top: 0.75rem; margin-bottom: 0.75rem`), but `.rich-editor-body` (edit mode) had no paragraph spacing defined, relying on browser defaults. This caused visual discrepancy where line breaks appeared in edit mode but not in read-only view.

## Changes

- Added paragraph spacing rules to `.rich-editor-body p` to match `.prose p`
- Added `:first-child` and `:last-child` pseudo-selectors to prevent excess spacing
- Line-height set to 1.75 for consistent text flow

### Before

```css
/* .rich-editor-body had NO paragraph spacing */
.rich-editor-body ul { ... }
.rich-editor-body ol { ... }
```

### After

```css
.rich-editor-body p {
  margin-top: 0.75rem;
  margin-bottom: 0.75rem;
  line-height: 1.75;
}

.rich-editor-body p:first-child {
  margin-top: 0;
}

.rich-editor-body p:last-child {
  margin-bottom: 0;
}
```

## Test Plan

1. Create a new journal entry with multiple paragraphs
2. Add line breaks between paragraphs
3. Switch between edit mode and read-only mode
4. Verify spacing is identical in both modes

### Testing on Vercel Preview

- [ ] Create paragraphs with single line breaks
- [ ] Create paragraphs with double line breaks
- [ ] Verify spacing in edit mode matches read-only mode
- [ ] Test in both light and dark modes
- [ ] Verify no regression for lists, blockquotes, or other formatting

## Screenshots

_Will add screenshots after Vercel preview deployment_

## Affected Files

- `src/app/globals.css` - Added paragraph spacing to `.rich-editor-body p`

## Notes

- Build passes: ✅ `npm run build` successful
- No changes to HTML structure or sanitization logic needed
- Tags (`<br>`, `<p>`) were already whitelisted in `sanitizeHtml.ts`
- Fix follows project pattern: matching styles between `.rich-editor-body` and `.prose`