### PR TITLE
Simplify note modal to encourage dedicated note page usage

### DIFF
--- a/src/components/notes/NoteViewer.tsx
+++ b/src/components/notes/NoteViewer.tsx
@@ -244,7 +244,10 @@ export function NoteViewer({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex-1 overflow-y-auto py-4">
+        <div
+          className="flex-1 overflow-y-auto py-4 cursor-pointer hover:bg-muted/30 transition-colors rounded-md"
+          onClick={isEditing ? undefined : handleEdit}
+        >
           {isEditing ? (
             <SimpleRichEditor
               value={editContent}


### PR DESCRIPTION
## Summary
Simplified the note viewer modal to serve as a quick preview only, encouraging users to use the dedicated note page for editing and detailed viewing.

Fixes #133

## Changes

### Removed
- ❌ "Close" button in modal footer
- ❌ "Press Esc to close" hint text

### Modified
- 🔄 **Edit button**: Now icon-only (removed "Edit" text), clicking navigates to `/notes/[id]` page
- 🔄 **Note title**: Now clickable with hover effect, navigates to `/notes/[id]` page
- 🔄 **Note body**: Now clickable with hover effect, navigates to `/notes/[id]` page (scroll still works)

### Unchanged
- ✅ Esc key still closes modal (just removed the hint text)
- ✅ Delete button remains functional in modal
- ✅ Modal X button in top-right still closes modal
- ✅ Scrolling works normally in the note body

## Rationale
The modal should serve as a quick preview only. For editing or detailed viewing, users should use the dedicated note page which provides:
- Better UX with full sidebar navigation
- More screen real estate for content
- Consistent editing experience with autosave
- Better context for the note within the app structure

## Screenshots
### Before
![Screenshot from issue showing modal with Close button and "Press Esc to close" text](https://github.com/user-attachments/assets/431ce1a7-2aca-4782-91f4-87e9ea5a11ec)

### After
- Title is now clickable (hover shows color change to primary)
- Edit button shows only pencil icon
- Note body is clickable (hover shows subtle background)
- Clean footer with no clutter

## Test Plan
- [x] Build passes (`npm run build`)
- [ ] Click note title → navigates to `/notes/[id]` page
- [ ] Click Edit icon → navigates to `/notes/[id]` page
- [ ] Click note body → navigates to `/notes/[id]` page
- [ ] Scrolling still works in note body
- [ ] Esc key still closes modal
- [ ] Modal X button still closes modal
- [ ] Delete button still works in modal
- [ ] Test on Vercel preview deployment

## Testing on Vercel Preview
After Vercel deploys, test the following on the preview URL:
1. Open a note in modal (click a linked note from journal)
2. Verify title is clickable and navigates correctly
3. Verify Edit icon navigates to note page
4. **Verify note body is clickable and navigates to note page**
5. **Verify scrolling still works in note body (for long notes)**
6. Verify Esc key closes modal
7. Verify no Close button or hint text in footer
8. Verify Delete button still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notes now open in a dedicated editing page when editing is initiated
  * Note titles and content are clickable to start editing

* **Improvements**
  * Title and content gain hover styling for clearer interaction affordance
  * Modal UI simplified: footer controls (Esc hint and Close button) removed
  * Edit control streamlined and improved accessibility labeling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->