### PR TITLE
Fix: Complete metadata persistence for rejected tasks (Codex review fixes)

### DIFF
--- a/src/components/journal/JournalStream.tsx
+++ b/src/components/journal/JournalStream.tsx
@@ -442,25 +442,30 @@ export function JournalStream({ isGuest = false }: JournalStreamProps) {
         const currentRejectedHashes = rejectedTaskHashes.get(entryId)
         const rejectedHashesArray = currentRejectedHashes ? Array.from(currentRejectedHashes) : undefined
 
+        const updatedMetadata = {
+          ...(entry?.metadata || {}),
+          tasks: tasks.map(t => ({
+            id: t.id,
+            paragraphHash: t.paragraphHash,
+            status: t.status
+          })),
+          // Include rejected hashes if any exist in state
+          ...(rejectedHashesArray && rejectedHashesArray.length > 0
+            ? { rejectedTaskHashes: rejectedHashesArray }
+            : {})
+        }
+
         try {
           await updateNoteInDb(
             entryId,
-            {
-              metadata: {
-                ...(entry?.metadata || {}),
-                tasks: tasks.map(t => ({
-                  id: t.id,
-                  paragraphHash: t.paragraphHash,
-                  status: t.status
-                })),
-                // Include rejected hashes if any exist in state
-                ...(rejectedHashesArray && rejectedHashesArray.length > 0
-                  ? { rejectedTaskHashes: rejectedHashesArray }
-                  : {})
-              }
-            },
+            { metadata: updatedMetadata },
             user.id
           )
+
+          // Update entries state to keep it in sync with DB after successful save
+          setEntries(prev => prev.map(e =>
+            e.id === entryId ? { ...e, metadata: updatedMetadata } : e
+          ))
         } catch (error) {
           console.error(`Failed to save task metadata for entry ${entryId}:`, error)
         }


### PR DESCRIPTION
## Summary

This PR completes the fix for duplicate task re-appearance by addressing 4 nested metadata persistence issues discovered during Codex review of PR #135.

## Background

After PR #135 was merged, Codex identified that rejected task hashes were still being lost due to multiple layers of metadata handling issues. Each commit addresses a specific layer in the data flow.

## Fixes Included

### 1. Null Metadata Guard (ffcc592)
- **Issue**: Spreading `currentNote.metadata` without null check caused TypeError for legacy journal entries
- **Fix**: Added `...(currentNote.metadata || {})` when persisting rejected hashes
- **Location**: Task rejection handler

### 2. Metadata Overwrite in Autosave (1730ee2)
- **Issue**: Debounced autosave created new metadata object with only `tasks` array, dropping `rejectedTaskHashes`
- **Fix**: Merged existing `entry.metadata` before adding tasks
- **Location**: Debounced metadata saver

### 3. Missing State Sync (fd5ab46)
- **Issue**: `entry.metadata` didn't include newly rejected hashes (only in `rejectedTaskHashes` state Map)
- **Fix**: Explicitly merged current `rejectedTaskHashes` from state into metadata updates
- **Location**: Debounced metadata saver

### 4. Dropped Metadata in Loader (ec59ca9)
- **Issue**: Note loader was dropping `note.metadata` when mapping Supabase notes to `journalEntries`
- **Fix**: Preserved `note.metadata` in `JournalEntry` interface and mapping
- **Location**: Note loader

## Complete Data Flow

Now the full persistence flow works correctly:

```
1. Load from DB → entries state (with metadata) ✓
2. User rejects task → rejectedTaskHashes state ✓
3. Rejection handler → persists to DB ✓
4. Autosave merges:
   - entry.metadata (from DB via loader) ✓
   - rejectedTaskHashes (from state) ✓
   - tasks (current tasks) ✓
5. Rejected tasks persist across reloads ✓
```

## Test Plan

- [ ] Test on Vercel preview deployment
- [ ] Reject a task in a journal entry
- [ ] Verify task disappears from UI
- [ ] Make another edit to trigger autosave
- [ ] Reload the page
- [ ] Verify rejected task does not reappear
- [ ] Test with legacy journal entries (null metadata)
- [ ] Verify no console errors during autosave

## Related

- Closes issues discovered in Codex review of #135
- Builds on: #135

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rejected tasks are now properly remembered and persisted across sessions within journal entries.
  * Enhanced metadata preservation during autosave operations to ensure rejection history and additional entry context are maintained consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->