### PR TITLE
feat: Default to sign-up for new users, remember returning users

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -6,9 +6,19 @@ import { useAuth } from '@/contexts/AuthContext'
 import { AuthForms } from '@/components/auth/AuthForms'
 
 export default function AuthPage() {
-  const [mode, setMode] = useState<'signin' | 'signup'>('signin')
+  const [mode, setMode] = useState<'signin' | 'signup'>(() => {
+    // Default to signup for new users, signin for returning users
+    if (typeof window === 'undefined') return 'signup'
+    const hasVisited = localStorage.getItem('signum_has_visited')
+    return hasVisited ? 'signin' : 'signup'
+  })
   const { user, loading } = useAuth()
   const router = useRouter()
+
+  useEffect(() => {
+    // Mark user as having visited the auth page
+    localStorage.setItem('signum_has_visited', 'true')
+  }, [])
 
   useEffect(() => {
     if (!loading && user) {


### PR DESCRIPTION
## Summary

Improves the auth flow UX by defaulting to sign-up for first-time visitors while remembering returning users:

- ✅ First-time visitors see "Create Account" / Sign Up form (reduces friction for new users)
- ✅ Returning visitors see "Welcome Back" / Sign In form (based on localStorage)
- ✅ Follows industry best practices (Notion, Linear, Superhuman all default to sign-up)

## Changes

**File:** `src/app/auth/page.tsx`

1. Changed default mode from `'signin'` to `'signup'` using lazy state initialization
2. Added localStorage check: if `signum_has_visited` exists, show sign-in
3. Added useEffect to set `signum_has_visited` flag on page visit

## Implementation Details

```typescript
// Lazy initialization checks localStorage
const [mode, setMode] = useState<'signin' | 'signup'>(() => {
  if (typeof window === 'undefined') return 'signup'
  const hasVisited = localStorage.getItem('signum_has_visited')
  return hasVisited ? 'signin' : 'signup'
})

// Mark user as having visited
useEffect(() => {
  localStorage.setItem('signum_has_visited', 'true')
}, [])
```

## Test Plan

### On Vercel Preview:

1. **First-time visitor flow:**
   - [ ] Open preview URL in incognito/private window
   - [ ] Verify "Create Account" form is displayed by default
   - [ ] Verify tagline shows "Create your account to start journaling with Signum"
   - [ ] Verify can toggle to "Sign in" form

2. **Returning visitor flow:**
   - [ ] Visit preview URL in normal browser (after step 1)
   - [ ] Close browser tab
   - [ ] Reopen preview URL
   - [ ] Verify "Welcome Back" / Sign In form is displayed
   - [ ] Verify tagline shows "Sign in to your Signum account"

3. **LocalStorage verification:**
   - [ ] Open DevTools → Application → Local Storage
   - [ ] Verify `signum_has_visited: "true"` is set after visiting /auth

4. **Reset test:**
   - [ ] Clear localStorage in DevTools
   - [ ] Refresh page
   - [ ] Verify Sign Up form is shown again

## Why This Matters

As a new app focused on user acquisition, defaulting to sign-up:
- Reduces cognitive friction for new users
- Aligns with growth-stage app best practices
- Still provides good UX for returning users via localStorage

## Related

Resolves #117

---

**Co-Authored-By:** Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication page now intelligently defaults to sign-in for returning users and sign-up for first-time visitors, improving user experience and reducing unnecessary navigation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->