### PR TITLE
feat: Add /bmad-refresh slash command for easy BMAD setup

### DIFF
--- a/.claude/commands/bmad-refresh.md
+++ b/.claude/commands/bmad-refresh.md
@@ -1,0 +1,7 @@
+---
+description: Install/refresh BMAD Method in current workspace (project)
+---
+
+Run `npm run bmad:refresh` immediately without any other actions or questions.
+
+After the command completes successfully, run `npm run bmad:validate` to verify the installation.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "eslint",
     "postinstall": "[ -z \"$VERCEL\" ] && printf 'y\\ny\\ny\\n' | bmad-method install -f -i codex || echo 'BMAD setup skipped (CI environment detected)'",
     "bmad:refresh": "printf 'y\\ny\\ny\\n' | bmad-method install -f -i codex",
-    "bmad:list": "bmad-method list:agents",
     "bmad:validate": "bmad-method status",
     "bmad-progress": "node tools/progress-tracking/update-progress.js 2>/dev/null || node .bmad-core/utils/update-progress.js",
     "bmad-progress:watch": "node tools/progress-tracking/progress-watcher.js 2>/dev/null || node .bmad-core/utils/progress-watcher.js",


### PR DESCRIPTION
## Summary

- Adds `/bmad-refresh` slash command for convenient BMAD installation in new Conductor workspaces
- Removes non-functional `bmad:list` npm script (command doesn't exist in bmad-method 4.44.1)

## Problem

In new Conductor workspaces, users need to manually run `npm run bmad:refresh` to set up BMAD. This is hard to remember and not discoverable.

## Solution

Created a slash command `/bmad-refresh` that:
- Executes `npm run bmad:refresh` immediately
- Validates installation with `npm run bmad:validate`
- Provides a memorable, autocomplete-friendly command

## Changes

1. **Added** `.claude/commands/bmad-refresh.md` - slash command definition
2. **Removed** `bmad:list` from package.json scripts (doesn't work in current bmad-method version)

## Test Plan

- [x] Open new Conductor workspace
- [x] Type `/bmad-refresh` in chat
- [x] Verify BMAD installs successfully
- [x] Confirm `npm run bmad:validate` shows successful installation

## Related

- Builds on PR #160 (cross-platform BMAD setup)
- Improves developer experience for Conductor multi-workspace workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for installing and refreshing the BMAD Method in your workspace using `npm run bmad:refresh` and `npm run bmad:validate` commands.

* **Chores**
  * Removed `bmad:list` script from available commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->