### PR TITLE
Hide redundant helper tiles

### DIFF
--- a/src/components/journal/JournalStream.tsx
+++ b/src/components/journal/JournalStream.tsx
@@ -770,11 +770,8 @@ export function JournalStream({ isGuest = false }: JournalStreamProps) {
                       'cbt-distortions',
                       'gratitude',
                       'values-affirmation',
-                      'self-compassion',
                       'woop',
                       'best-possible-self',
-                      'savoring',
-                      'loving-kindness',
                     ]}
                     onTileClick={(helperType) => {
                       setActiveHelper(helperType)

--- a/src/components/journal/helpers/BestPossibleSelfHelper.tsx
+++ b/src/components/journal/helpers/BestPossibleSelfHelper.tsx
@@ -27,6 +27,8 @@ import { createHelperUsage } from '@/lib/supabase/helpers'
 import { HelperEvent } from '@/types/helper'
 import { HelperContainer } from './HelperContainer'
 import { escapeHtml } from '@/utils/htmlEscape'
+import { HelperAddOn } from './HelperAddOn'
+import { LovingKindnessContent } from './LovingKindnessHelper'
 
 interface BestPossibleSelfHelperProps {
   entryId: string
@@ -237,6 +239,19 @@ export function BestPossibleSelfContent({ entryId, userId, onInsert }: BestPossi
           )}
         </div>
       </div>
+
+      <HelperAddOn
+        title="Open with a compassion warmup"
+        description="Use a short loving-kindness meditation to get into an expansive mindset before writing."
+        badge="Loving-Kindness"
+      >
+        <p className="text-sm text-gray-600 dark:text-gray-300 mb-3">
+          Direct a few metta phrases toward yourself or someone you care about, then continue writing about your future self.
+        </p>
+        <div className="rounded-md border border-rose-200/70 dark:border-rose-900/40 bg-white/60 dark:bg-gray-900/30 p-3">
+          <LovingKindnessContent entryId={entryId} userId={userId} onInsert={onInsert} />
+        </div>
+      </HelperAddOn>
 
       {/* Action buttons */}
       <div className="flex gap-2 pt-4 border-t border-green-200 dark:border-green-800 mt-4">

--- a/src/components/journal/helpers/GratitudeHelper.tsx
+++ b/src/components/journal/helpers/GratitudeHelper.tsx
@@ -23,6 +23,8 @@ import { createHelperUsage } from '@/lib/supabase/helpers'
 import { HelperEvent } from '@/types/helper'
 import { HelperContainer } from './HelperContainer'
 import { escapeHtml } from '@/utils/htmlEscape'
+import { HelperAddOn } from './HelperAddOn'
+import { SavoringContent } from './SavoringHelper'
 
 interface GratitudeHelperProps {
   entryId: string
@@ -410,6 +412,19 @@ export function GratitudeContent({ entryId, userId, onInsert }: GratitudeHelperP
             </div>
           ))}
         </div>
+
+        <HelperAddOn
+          title="Add a savoring boost"
+          description="Deepen one of your good things by walking through a savoring strategy."
+          badge="Savoring"
+        >
+          <p className="text-sm text-gray-600 dark:text-gray-300 mb-3">
+            Pick a Bryant &amp; Veroff strategy, describe the moment with sensory detail, and insert it right into your entry without leaving the gratitude flow.
+          </p>
+          <div className="rounded-md border border-pink-200/70 dark:border-pink-900/40 bg-white/60 dark:bg-gray-900/30 p-3">
+            <SavoringContent entryId={entryId} userId={userId} onInsert={onInsert} />
+          </div>
+        </HelperAddOn>
 
         {/* Action buttons */}
         <div className="flex gap-2 pt-4 border-t border-green-200 dark:border-green-800 mt-4">

--- a/src/components/journal/helpers/HelperAddOn.tsx
+++ b/src/components/journal/helpers/HelperAddOn.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { ReactNode, useState } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface HelperAddOnProps {
+  title: string
+  description: string
+  children: ReactNode
+  badge?: string
+}
+
+/**
+ * Lightweight accordion-style wrapper for optional helper content.
+ * Used to surface retired helpers inside other flows without crowding the grid.
+ */
+export function HelperAddOn({ title, description, children, badge }: HelperAddOnProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <section
+      className={cn(
+        'mt-6 rounded-lg border border-dashed border-gray-300 dark:border-gray-700',
+        'bg-white/60 dark:bg-gray-900/40'
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        aria-expanded={isOpen}
+        className={cn(
+          'w-full flex items-start justify-between gap-3 px-4 py-3 text-left',
+          'focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2'
+        )}
+      >
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <p className="font-semibold text-gray-900 dark:text-gray-100">{title}</p>
+            {badge && (
+              <span className="text-xs font-medium uppercase tracking-wide text-primary">
+                {badge}
+              </span>
+            )}
+          </div>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            {description}
+          </p>
+        </div>
+        <ChevronDown
+          className={cn(
+            'mt-1 flex-shrink-0 text-gray-500 transition-transform duration-200',
+            isOpen && 'rotate-180'
+          )}
+          aria-hidden="true"
+        />
+      </button>
+
+      {isOpen && (
+        <div className="px-4 pb-4 pt-3 border-t border-gray-200 dark:border-gray-800">
+          {children}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/journal/helpers/ValuesAffirmationHelper.tsx
+++ b/src/components/journal/helpers/ValuesAffirmationHelper.tsx
@@ -30,6 +30,8 @@ import { createHelperUsage } from '@/lib/supabase/helpers'
 import { HelperEvent } from '@/types/helper'
 import { HelperContainer } from './HelperContainer'
 import { escapeHtml } from '@/utils/htmlEscape'
+import { HelperAddOn } from './HelperAddOn'
+import { SelfCompassionContent } from './SelfCompassionHelper'
 
 // Evidence-based values list from ACT framework and Cohen research
 export const VALUES_OPTIONS = [
@@ -346,6 +348,19 @@ export function ValuesAffirmationContent({ entryId, userId, onInsert }: ValuesAf
             />
           </div>
         </div>
+
+        <HelperAddOn
+          title="Add a self-compassion reset"
+          description="Use Kristin Neff's three-step break when reflecting on tough value conflicts."
+          badge="Self-Compassion"
+        >
+          <p className="text-sm text-gray-600 dark:text-gray-300 mb-3">
+            Acknowledge the stressor, remember common humanity, and offer yourself kindness before finishing your values reflection.
+          </p>
+          <div className="rounded-md border border-amber-200/70 dark:border-amber-900/40 bg-white/60 dark:bg-gray-900/30 p-3">
+            <SelfCompassionContent entryId={entryId} userId={userId} onInsert={onInsert} />
+          </div>
+        </HelperAddOn>
 
       {/* Action buttons */}
       <div className="flex gap-2 pt-4 border-t border-purple-200 dark:border-purple-800 mt-4">

--- a/src/constants/helperTitles.ts
+++ b/src/constants/helperTitles.ts
@@ -27,13 +27,13 @@ export const HELPER_TILES: Record<HelperType, HelperTileData> = {
   },
   gratitude: {
     shortTitle: 'Gratitude',
-    description: 'Reflect on what went well today',
+    description: 'Reflect on what went well (plus optional savoring boost)',
     fullTitle: 'Gratitude Practice',
     icon: '✨',
   },
   'values-affirmation': {
     shortTitle: 'Values Affirmation',
-    description: 'Clarify what matters most to you',
+    description: 'Clarify what matters most with self-compassion tips',
     fullTitle: 'Values Affirmation',
     icon: '🎯',
   },
@@ -51,7 +51,7 @@ export const HELPER_TILES: Record<HelperType, HelperTileData> = {
   },
   'best-possible-self': {
     shortTitle: 'Best Self',
-    description: 'Envision your ideal future',
+    description: 'Envision your ideal future with a compassion warmup',
     fullTitle: 'Best Possible Self Exercise',
     icon: '🌟',
   },


### PR DESCRIPTION
Removes the Savoring, Self-Compassion, and Loving-Kindness helpers from the tile grid and introduces a reusable HelperAddOn accordion for optional flows. Folds each retired helper’s content into Gratitude, Values Affirmation, and Best Possible Self add-ons and updates tile descriptions so the embedded practices stay discoverable. Tests: 
> signum-app@0.1.0 lint
> eslint


/Users/andrewleveiss/Signum/.conductor/dakar/scripts/detect-query-tasks.ts
  29:11  warning  'Task' is defined but never used  @typescript-eslint/no-unused-vars

/Users/andrewleveiss/Signum/.conductor/dakar/src/components/journal/JournalStream.tsx
  494:6  warning  React Hook useEffect has missing dependencies: 'entries' and 'rejectedTaskHashes'. Either include them or remove the dependency array  react-hooks/exhaustive-deps

/Users/andrewleveiss/Signum/.conductor/dakar/src/lib/crypto/migration.ts
  10:11  warning  'MigrationProgress' is defined but never used  @typescript-eslint/no-unused-vars

✖ 3 problems (0 errors, 3 warnings) (warnings only: existing unused variable + react-hooks dependencies).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added collapsible helper add-ons (compassion warmup, savoring boost, self‑compassion reset) embedded directly into relevant journaling helpers.

* **UI Changes**
  * Removed the separate standalone helper tiles from the today's-entry tile grid and updated helper descriptions to reflect the new in-flow add-ons.
  * Introduced compact accordion-style add-on panels for a cleaner, on-demand experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->