### PR TITLE
Fix E2E test port mismatch and remove Co-Authored-By requirement

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8,7 +8,7 @@ This project uses PR-based deployment with auto-deploy to Vercel. You MUST follo
 
 1. **Create feature branch**: `git checkout -b story-X.X-description`
 2. **Make changes & test locally**: `npm run build`, verify functionality
-3. **Commit & push**: `git add [files] && git commit` with `Co-Authored-By: Claude <noreply@anthropic.com>`, then `git push`
+3. **Commit & push**: `git add [files] && git commit`, then `git push`
 4. **Create PR**: `gh pr create` with description, test plan, screenshots. Apply appropriate labels (see GitHub Labels below).
 5. **🚨 Codex review**: CI auto-comments `@codex review` after push. If not posted within ~30s, run manually: `gh pr comment [PR#] --body '@codex review'`
 6. **Test on Vercel Preview**: Test thoroughly on preview URL

--- a/tests/cbt-distortions-helper.spec.ts
+++ b/tests/cbt-distortions-helper.spec.ts
@@ -1,11 +1,9 @@
 import { test, expect } from '@playwright/test'
 
-const TEST_URL = 'http://localhost:3000'
-
 test.describe('CBT Distortions Helper', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to journal page
-    await page.goto(TEST_URL)
+    await page.goto('/')
     await page.waitForLoadState('networkidle')
 
     // Wait for journal entry to load (assumes authentication is already set up)

--- a/tests/hyperlink-verification.test.ts
+++ b/tests/hyperlink-verification.test.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test.describe('Hyperlink Verification', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to the application
-    await page.goto('http://localhost:3000');
+    await page.goto('/');
 
     // Wait for the journal stream to load
     await page.waitForSelector('[data-entry-id]', { timeout: 10000 });

--- a/tests/hyperlink.test.ts
+++ b/tests/hyperlink.test.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test.describe('Hyperlink Creation from Selected Text', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to the application
-    await page.goto('http://localhost:3000');
+    await page.goto('/');
 
     // Wait for the journal stream to load
     await page.waitForSelector('[data-entry-id]', { timeout: 10000 });

--- a/tests/ontology-page.test.ts
+++ b/tests/ontology-page.test.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test.describe('Ontology Page', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to the ontology page
-    await page.goto('http://localhost:3000/ontology');
+    await page.goto('/ontology');
 
     // Wait for the page to load
     await page.waitForLoadState('networkidle');


### PR DESCRIPTION
## Summary

- Fixed `ERR_CONNECTION_REFUSED` errors in E2E tests by updating hardcoded `localhost:3000` URLs to use relative paths
- Removed Co-Authored-By requirement from workflow documentation per user preference

## Root Cause

E2E tests were failing in CI because:
- Playwright's `webServer` config starts Next.js on port **3001**
- 4 test files hardcoded `http://localhost:3000` URLs
- Tests that use relative paths (which respect `baseURL`) were passing
- Tests with hardcoded port 3000 were failing with connection refused

## Changes

### Test Files Fixed (4 files)
- `tests/cbt-distortions-helper.spec.ts` - Removed `TEST_URL` constant, changed to relative path
- `tests/hyperlink.test.ts` - Changed `page.goto('http://localhost:3000')` to `page.goto('/')`
- `tests/hyperlink-verification.test.ts` - Changed `page.goto('http://localhost:3000')` to `page.goto('/')`
- `tests/ontology-page.test.ts` - Changed `page.goto('http://localhost:3000/ontology')` to `page.goto('/ontology')`

### Documentation Update
- `.claude/CLAUDE.md` - Removed `Co-Authored-By: Claude <noreply@anthropic.com>` requirement from commit workflow

## Test Plan

- [ ] Wait for CI E2E tests to pass (especially the previously failing tests)
- [ ] Verify smoke tests complete successfully
- [ ] Confirm no regression in other tests

## Technical Details

**Why this works:** Playwright's `baseURL` configuration is set to `http://localhost:3001` (see `playwright.config.ts:8`). Using relative paths like `/` or `/ontology` automatically resolves to the correct baseURL, ensuring tests connect to the port where the webServer is actually running.

Tests that were already passing used relative URLs and therefore already respected the `baseURL` configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test navigation to use relative paths instead of hardcoded URLs, improving test configuration flexibility.

* **Chores**
  * Removed metadata from commit instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->