### PR TITLE
feat: Reduce note editor padding to match journal UI (Issue #178)

### DIFF
--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 import { getNoteById, updateNote, deleteNote } from '@/lib/notes'
 import { Note, getNoteDisplayTitle } from '@/types/note'
 import { Button } from '@/components/ui/button'
-import { Card } from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import { Trash2 } from 'lucide-react'
 import { OntologyCardViewer } from '@/components/notes/OntologyCardViewer'
 import { useAuth } from '@/contexts/AuthContext'
@@ -430,13 +430,14 @@ export default function NoteEditPage({ params }: { params: Promise<{ id: string 
           </div>
         ) : (
           // Rich text editor for regular notes - matches JournalStream.tsx pattern
-          <Card className="p-6">
-            <div
+          <Card className="py-0">
+            <CardContent
               onClick={() => setIsEditing(true)}
-              className="cursor-text hover:bg-muted/30 p-2 rounded-md transition-colors"
+              className="px-3 md:px-2 pb-3 md:pb-2 pt-0 cursor-text hover:bg-muted/30 rounded-md transition-colors"
             >
               {isEditing ? (
                 <SimpleRichEditor
+                  variant="flush"
                   value={content}
                   placeholder={`Write your ${note.title.toLowerCase()} here...`}
                   onChange={handleContentChange}
@@ -449,7 +450,7 @@ export default function NoteEditPage({ params }: { params: Promise<{ id: string 
                   {content ? (
                     isDOMPurifyReady ? (
                       <div
-                        className="text-base leading-relaxed prose prose-sm max-w-none"
+                        className="text-base leading-relaxed prose prose-sm max-w-none px-2"
                         dangerouslySetInnerHTML={{ __html: sanitizeHtml(content) }}
                         onClick={(e) => {
                           // Handle link clicks in read-only mode
@@ -476,7 +477,7 @@ export default function NoteEditPage({ params }: { params: Promise<{ id: string 
                   )}
                 </div>
               )}
-            </div>
+            </CardContent>
           </Card>
         )}
       </div>

--- a/src/components/notes/NoteViewer.tsx
+++ b/src/components/notes/NoteViewer.tsx
@@ -245,18 +245,19 @@ export function NoteViewer({
         </DialogHeader>
 
         <div
-          className="flex-1 overflow-y-auto py-4 cursor-pointer hover:bg-muted/30 transition-colors rounded-md"
+          className="flex-1 overflow-y-auto px-3 md:px-2 pb-3 md:pb-2 pt-0 cursor-pointer hover:bg-muted/30 transition-colors rounded-md"
           onClick={isEditing ? undefined : handleEdit}
         >
           {isEditing ? (
             <SimpleRichEditor
+              variant="flush"
               value={editContent}
               placeholder="Write your note content here..."
               onChange={setEditContent}
               autoFocus={false}
             />
           ) : (
-            <div className="prose prose-sm max-w-none">
+            <div className="prose prose-sm max-w-none px-2">
               {note.content ? (
                 isDOMPurifyReady ? (
                   <div


### PR DESCRIPTION
## Summary

Extends the padding reduction work from Issue #178 to the notes UI. Applies the same CardContent pattern and flush variant approach used in journal entries to eliminate nested container padding.

## Changes

### Files Modified
1. **`src/app/notes/[id]/page.tsx`**
   - Import `CardContent` from `@/components/ui/card`
   - Change Card: `p-6` → `py-0` (override shadcn default)
   - Wrap content in `CardContent` with responsive padding: `px-3 md:px-2 pb-3 md:pb-2 pt-0`
   - Add `variant="flush"` to SimpleRichEditor
   - Add `px-2` to read-only prose div for consistency

2. **`src/components/notes/NoteViewer.tsx`**
   - Update container: `py-4` → `px-3 md:px-2 pb-3 md:pb-2 pt-0`
   - Add `variant="flush"` to SimpleRichEditor
   - Add `px-2` to read-only prose div

### WYSIWYG Toolbar Changes
The `variant="flush"` prop automatically repositions the toolbar:
- **Before**: Toolbar above content with `border-t`
- **After**: Toolbar below content with full `border rounded-md`
- Matches journal UI exactly

### Padding Reduction
**Before**:
- Card `p-6` (24px) + container `p-2` (8px) + editor `p-4` (16px) = **48px per side**
- Total width lost: **96px**

**After**:
- Mobile: CardContent `px-3` (12px) + editor `px-2` (8px) = **20px per side** (40px total)
- Desktop: CardContent `px-2` (8px) + editor `px-2` (8px) = **16px per side** (32px total)
- **Reduction: 58-67%**

## Test Plan

- [ ] Note detail page (`/notes/[id]`): Click to edit, verify padding reduced and toolbar appears below
- [ ] Note modal (NoteViewer): Same padding/toolbar behavior in modal context
- [ ] Mobile responsive: Padding reduces from 12px to 8px at md breakpoint
- [ ] Edit mode: WYSIWYG toolbar positioned below content with full border
- [ ] Read-only mode: Content displays with correct `px-2` padding
- [ ] Mode switching: No layout shift when toggling edit/read-only
- [ ] Auto-save: Still works after 2s of inactivity
- [ ] Make Note: Selecting text and creating linked note still works
- [ ] Note links: Clicking links in read-only opens NoteViewer modal

## Screenshots

_Will add after Vercel preview deployment_

## Related

- Issue #178
- Previous PR that fixed journal UI: #184

Co-Authored-By: Claude <noreply@anthropic.com>