### PR TITLE
Fix read-only journal padding/contrast

### DIFF
--- a/src/components/journal/JournalStream.tsx
+++ b/src/components/journal/JournalStream.tsx
@@ -1225,7 +1225,7 @@ export function JournalStream({ isGuest = false }: JournalStreamProps) {
                     {!isContentEmpty(entry.content) ? (
                       isDOMPurifyReady ? (
                         <div
-                          className="text-base leading-relaxed prose prose-sm max-w-none text-foreground [--tw-prose-body:var(--foreground)] [--tw-prose-headings:var(--foreground)] [--tw-prose-bold:var(--foreground)] [--tw-prose-links:var(--primary)] mx-[-12px] md:mx-[-8px]"
+                          className="text-base leading-relaxed text-foreground rich-editor-body"
                           dangerouslySetInnerHTML={{ __html: sanitizeHtml(entry.content) }}
                           onClick={(e) => {
                             // Handle link clicks in read-only mode


### PR DESCRIPTION
# Pull Request

## Description
Tightens read-only journal entry styling by removing extra horizontal padding and forcing foreground text color for proper contrast.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Configuration change

## Testing Checklist
- [ ] Tested locally with `npm run dev`
- [ ] Tested build with `npm run build`
- [ ] Tested on Vercel preview deployment
- [ ] All existing tests pass

## Security Review Checklist
- [ ] **Data Isolation:** Changes respect user data boundaries (no shared user IDs)
- [ ] **RLS Policies:** Database queries enforce Row-Level Security
- [ ] **Auth Integration:** Protected routes use proper authentication
- [ ] **Environment Variables:** No hardcoded secrets or credentials
- [ ] **API Security:** External API calls use proper authentication

## Deployment Notes
None.

## Screenshots
Not applicable.

## Related Issues
- #198


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated journal entry presentation: refined typography, improved text and link colors, and adjusted spacing for cleaner, more readable display of sanitized journal content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->