### PR TITLE
Fix notes read-only text contrast and spacing

### DIFF
--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -564,7 +564,7 @@ const linkSelectionToNote = async (targetNoteId: string, createdNote?: Note) => 
                   {content ? (
                     isDOMPurifyReady ? (
                       <div
-                        className="text-base leading-relaxed prose prose-sm max-w-none px-2"
+                        className="text-base leading-relaxed text-foreground rich-editor-body"
                         dangerouslySetInnerHTML={{ __html: sanitizeHtml(content) }}
                         onClick={(e) => {
                           // Handle link clicks in read-only mode

--- a/src/components/notes/NoteViewer.tsx
+++ b/src/components/notes/NoteViewer.tsx
@@ -298,11 +298,11 @@ export function NoteViewer({
               autoFocus={false}
             />
           ) : (
-            <div className="prose prose-sm max-w-none px-2">
+            <>
               {note.content ? (
                 isDOMPurifyReady ? (
                   <div
-                    className="text-base leading-relaxed"
+                    className="text-base leading-relaxed text-foreground rich-editor-body"
                     dangerouslySetInnerHTML={{ __html: sanitizeHtml(note.content) }}
                   />
                 ) : (
@@ -311,7 +311,7 @@ export function NoteViewer({
               ) : (
                 <p className="text-muted-foreground italic">This note has no content.</p>
               )}
-            </div>
+            </>
           )}
         </div>
       </DialogContent>


### PR DESCRIPTION
# Pull Request

## Description
- Align note read-only rendering with journal styling so text uses `rich-editor-body` and `text-foreground` for proper contrast/spacing.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Configuration change

## Testing Checklist
- [ ] Tested locally with `npm run dev`
- [ ] Tested build with `npm run build`
- [ ] Tested on Vercel preview deployment
- [ ] All existing tests pass

## Security Review Checklist
- [x] **Data Isolation:** Changes respect user data boundaries (no shared user IDs)
- [x] **RLS Policies:** Database queries enforce Row-Level Security
- [x] **Auth Integration:** Protected routes use proper authentication
- [x] **Environment Variables:** No hardcoded secrets or credentials
- [x] **API Security:** External API calls use proper authentication

## Deployment Notes
- None

## Screenshots
- None

## Related Issues
- https://github.com/levineam/Signum/issues/209
